### PR TITLE
Optimize CI pipeline structure and caching

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout repository
@@ -20,14 +21,22 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install pipeline dependencies
-        run: pip install -r requirements.txt
+        run: pip install pytest pytest-benchmark psutil
 
       - name: Build NumPy from source
         run: python scripts/build_numpy.py
 
       - name: Run functional tests
-        run: pytest tests/functional/ -v
+        run: pytest tests/functional/ -v --junitxml=functional_results.xml
 
       - name: Run performance tests (pytest-benchmark)
         run: |
@@ -37,26 +46,30 @@ jobs:
             --benchmark-min-rounds=5 \
             --benchmark-warmup=on \
             --benchmark-disable-gc \
-            --benchmark-sort=mean
+            --benchmark-sort=mean \
+            --junitxml=performance_results.xml
 
-      - name: Upload benchmark results as artifact
+      - name: Upload test results as artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: benchmark-results-${{ github.run_id }}
+          name: test-results-${{ github.run_id }}
           path: |
+            functional_results.xml
+            performance_results.xml
             benchmark_results.json
             .benchmarks/
 
       - name: Compare benchmarks against baseline (if available)
+        if: always()
         run: |
-          if [ -f baseline_benchmark.json ]; then
-            pytest-benchmark compare baseline_benchmark.json benchmark_results.json \
+          if [ -f baseline_benchmark.json ] && [ -f benchmark_results.json ]; then
+            python -m pytest-benchmark compare baseline_benchmark.json benchmark_results.json \
               --csv=benchmark_comparison.csv || true
             echo "--- Benchmark Comparison ---"
             cat benchmark_comparison.csv
           else
-            echo "No baseline found — skipping comparison. Save benchmark_results.json as baseline_benchmark.json to enable this step."
+            echo "No baseline or results found — skipping comparison."
           fi
 
       - name: Display test summary
@@ -65,14 +78,17 @@ jobs:
           echo "========================================"
           echo "        OOB NumPy Test Summary          "
           echo "========================================"
-          pytest tests/ --tb=no -q || true
-          echo ""
-          echo "--- Benchmark JSON Preview ---"
-          cat benchmark_results.json | python3 -c "
-          import json, sys
-          data = json.load(sys.stdin)
+          if [ -f benchmark_results.json ]; then
+            echo "--- Benchmark JSON Preview ---"
+            python3 -c "
+          import json
+          with open('benchmark_results.json') as f:
+              data = json.load(f)
           for b in data.get('benchmarks', []):
               name = b['name']
               mean = b['stats']['mean'] * 1000
               print(f'  {name}: {mean:.4f} ms (mean)')
-          " || true
+            " || true
+          else
+            echo "No benchmark results file found."
+          fi


### PR DESCRIPTION
Closes #9

## Summary of changes

- **Added `timeout-minutes: 60`** to prevent infinite hangs during the NumPy source build.
- **Added pip dependency caching** (`actions/cache@v4`) to speed up subsequent runs.
- **Removed `numpy` from the `pip install` step** — NumPy is built from source by `build_numpy.py`; installing it from PyPI beforehand was contradictory and wasteful.
- **Removed the duplicate `pytest tests/` call** from the summary step — tests now run only once; results are preserved via `--junitxml` artifacts.
- **Added `--junitxml` output** to both test steps for structured, artifact-friendly reporting.
- **Fixed benchmark results guarding** — comparison and summary steps now verify `benchmark_results.json` exists before reading it.
- **Consolidated artifact upload** — functional results, performance results, and benchmark JSON are all uploaded in a single step.